### PR TITLE
Transactions stream endpoint added

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,14 @@ options = {
 client.account('account_id').transactions_since_id(options).show
 ```
 
+```ruby
+client = OandaApiV20.new(access_token: 'my_access_token', stream: true)
+
+client.account('account_id').transactions_stream.show do |json|
+  puts json if json['type'] != 'HEARTBEAT'
+end
+```
+
 ### Pricing
 
 See the [Oanda Documentation](http://developer.oanda.com/rest-live-v20/pricing-ep/) for all available options on pricing.

--- a/lib/oanda_api_v20/transactions.rb
+++ b/lib/oanda_api_v20/transactions.rb
@@ -20,5 +20,31 @@ module OandaApiV20
     def transactions_since_id(options)
       Client.send(http_verb, "#{base_uri}/accounts/#{account_id}/transactions/sinceid", headers: headers, query: options)
     end
+
+    # GET /v3/accounts/:account_id/transactions/stream
+    def transactions_stream(options = {}, &block)
+      buffer = String.new
+
+      Client.send(http_verb, "#{base_uri}/accounts/#{account_id}/transactions/stream", headers: headers, query: options, stream_body: true) do |fragment|
+        if !fragment.empty?
+          buffer << fragment
+          parse(buffer, fragment, &block) if fragment.match(/\n\Z/)
+        end
+      end
+    end
+
+    private
+
+    def parse(buffer, fragment, &block)
+      buffer.split("\n").each do |message|
+        cleaned_message = message.strip
+        next if cleaned_message.empty?
+        yield JSON.parse(cleaned_message)
+      end
+    rescue JSON::ParserError => e
+      raise OandaApiV20::ParseError, "#{e.message} in '#{fragment}'"
+    ensure
+      buffer.clear
+    end
   end
 end


### PR DESCRIPTION
I've added support for transactions stream endpoint. The changes complete the implementation of the transaction endpoint as this one was missing in the gem.

Readme and tests updated as well.